### PR TITLE
Grands

### DIFF
--- a/pluralizefr/__init__.py
+++ b/pluralizefr/__init__.py
@@ -8,6 +8,9 @@ http://fr.wiktionary.org/wiki/Annexe:Pluriels_irr%C3%A9guliers_en_fran%C3%A7ais
 
 
 def pluralize(word):
+    if word.startswith("grand-") and word[6:] in ["père", "oncle", "parent", "cousin"]:
+        word = "grands-" + word[6:]
+
     for GRAMMAR_RULE in (_ail_word, _al_word, _au_word, _eil_word, _eu_word, _ou_word, _s_word, _x_word, _z_word,
             _default):
         plural = GRAMMAR_RULE(word)
@@ -80,6 +83,9 @@ def _default(word):
 
 
 def singularize(word):
+    if word.startswith("grands-"):
+        word = "grand-" + word[7:]
+
     for GRAMMAR_RULE in (_eau_word_sing, _ail_word_sing, _eil_word_sing, _eu_word_sing, _ou_word_sing, _s_word_sing, _default_sing):
         singular = GRAMMAR_RULE(word)
         if singular:

--- a/pluralizefr/__init__.py
+++ b/pluralizefr/__init__.py
@@ -30,7 +30,7 @@ def _al_word(word):
             "bal", "carnaval", "chacal", "festival", u"récital", u"régal",
             "bancal", "fatal", "fractal", "final", "morfal", "natal", "naval",
             u"aéronaval",
-            u"anténatal", u"néonatal", u"périnatal", u"postnatal", u"prénatal",
+            u"anténatal", u"néonatal", u"périnatal", "postnatal", u"prénatal",
             "tonal", "atonal", "bitonal", "polytonal",
             "corral", "deal", "goal", "autogoal", "revival", "serial", "spiritual", "trial",
             "caracal", "chacal", "gavial", "gayal", "narval", "quetzal", "rorqual", "serval",

--- a/tests/pluralize_tests.py
+++ b/tests/pluralize_tests.py
@@ -164,6 +164,14 @@ class TestWordEndsWithEu(_Test):
         self.check("rebeu", "rebeus")
 
 
+class TestWordStartWithGrand(_Test):
+    def test_default(self):
+        self.check("grand-mère", "grand-mères")
+
+    def test_masculine(self):
+        self.check("grand-père", "grands-pères")
+        self.check("grand-parent", "grands-parents")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pluralize_tests.py
+++ b/tests/pluralize_tests.py
@@ -130,8 +130,8 @@ class TestWordEndsWithAil(_Test):
 
 class TestWordEndsWithAu(_Test):
     def test_words_have_aux_plural(self):
-        self.assertEquals(pluralize(u"château"), u"châteaux")
-        self.assertEquals(pluralize("noyau"), "noyaux")
+        self.assertEqual(pluralize(u"château"), u"châteaux")
+        self.assertEqual(pluralize("noyau"), "noyaux")
 
     def test_some_words_are_special_cases(self):
         self.check("berimbau", "berimbaus")


### PR DESCRIPTION
* fixed the tests.
*  removed one `u` that wasn't even necessary in python 2, though I guess all of them could be removed.
* added handling for `grand-`

fixes https://github.com/sblondon/pluralizefr/issues/4